### PR TITLE
ENH: Parse HOME(~/) correctly

### DIFF
--- a/scripts/bash_pinyin_completion
+++ b/scripts/bash_pinyin_completion
@@ -44,6 +44,14 @@ _pinyin_completion() {
 
     local cur="${COMP_WORDS[COMP_CWORD]}"
 
+    # Detect "~/"
+    local homeStart
+    if [ "${cur:0:2}" = "~/" ]; then
+        homeStart=true
+    else
+        homeStart=false
+    fi
+
     # ignore empty
     [ -z "$cur" ] && return
 
@@ -120,8 +128,14 @@ _pinyin_completion() {
     done
     COMPREPLY=( "${unique_compreply[@]}" )
 
-    # # fix space postfix
-    # if ((${#COMPREPLY[@]} == 1)) && [[ ${COMPREPLY[0]} != */ ]]; then
-    #     compopt -o nospace 2>/dev/null
-    # fi
+    if [[ "$homeStart" == true ]]; then
+        local home="$HOME"
+        for i in "${!COMPREPLY[@]}"; do
+            case "${COMPREPLY[$i]}" in
+                "$home"/*)
+                    COMPREPLY[$i]="~${COMPREPLY[$i]#"$home"}"
+                    ;;
+            esac
+        done
+    fi
 }

--- a/scripts/bash_pinyin_completion
+++ b/scripts/bash_pinyin_completion
@@ -37,6 +37,11 @@ _comp_expand_glob() {
 }
 
 _pinyin_completion() {
+    # Check COMP_WORDS existence
+    if [ ${#COMP_WORDS[@]} -eq 0 ] || [ -z "${COMP_CWORD+x}" ]; then
+        return
+    fi
+
     local cur="${COMP_WORDS[COMP_CWORD]}"
 
     # ignore empty


### PR DESCRIPTION
- 修复了遇到空补全时的报错
- 之前的补全如果遇到 ~/ 会补全为绝对路径。现在修复了这个问题。